### PR TITLE
ensure dotfiles repo is cloned

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,31 +22,35 @@ define dotfiles (
   
   if ($create_bash_aliases) {
     file { "${user_home}/.bash_aliases":
-      ensure => link,
-      owner  => $user,
-      target => "${dotfiles_path}/bash_aliases",
+      ensure  => link,
+      owner   => $user,
+      target  => "${dotfiles_path}/bash_aliases",
+      require => Vcsrepo[$dotfiles_path],
     }
   }
 
   if ($create_gitconfig) {
     file { "${user_home}/.gitconfig":
-      ensure => link,
-      owner  => $user,
-      target => "${dotfiles_path}/gitconfig",
+      ensure  => link,
+      owner   => $user,
+      target  => "${dotfiles_path}/gitconfig",
+      require => Vcsrepo[$dotfiles_path],
     }
   }
 
   if ($manage_gitprompt) {
     file { "${user_home}/.bashrc_git":
-      ensure => link,
-      owner  => $user,
-      target => "${dotfiles_path}/bashrc_git",
+      ensure  => link,
+      owner   => $user,
+      target  => "${dotfiles_path}/bashrc_git",
+      require => Vcsrepo[$dotfiles_path],
     }
 
     file_line { "${user}_bashrc_gitprompt":
-      ensure => present,
-      path   => "${user_home}/.bashrc",
-      line   => '[ -f ~/.bashrc_git ] && . ~/.bashrc_git',
+      ensure  => present,
+      path    => "${user_home}/.bashrc",
+      line    => '[ -f ~/.bashrc_git ] && . ~/.bashrc_git',
+      require => File["${user_home}/.bashrc_git"],
     }
   }
 }

--- a/spec/defines/dotfiles_spec.rb
+++ b/spec/defines/dotfiles_spec.rb
@@ -88,9 +88,10 @@ describe 'dotfiles', :type => :define do
 
         it { is_expected.to contain_file($user_home + "/.bash_aliases")
           .with(
-            'ensure' => 'link',
-            'owner'  => $user,
-            'target' => $dotfiles_path + "/bash_aliases",
+            'ensure'  => 'link',
+            'owner'   => $user,
+            'target'  => $dotfiles_path + "/bash_aliases",
+            'require' => "Vcsrepo[" + $dotfiles_path + "]",
           )
         }
       end
@@ -105,8 +106,9 @@ describe 'dotfiles', :type => :define do
         it { is_expected.to contain_file($user_home + "/.gitconfig")
           .with(
             'ensure' => 'link',
-            'owner'  => $user,
-            'target' => $dotfiles_path + "/gitconfig",
+            'owner'   => $user,
+            'target'  => $dotfiles_path + "/gitconfig",
+            'require' => "Vcsrepo[" + $dotfiles_path + "]",
           )
         }
       end
@@ -119,16 +121,18 @@ describe 'dotfiles', :type => :define do
         end
         it { is_expected.to contain_file($user_home + "/.bashrc_git")
           .with(
-            'ensure' => 'link',
-            'owner'  => $user,
-            'target' => $dotfiles_path + "/bashrc_git",
+            'ensure'  => 'link',
+            'owner'   => $user,
+            'target'  => $dotfiles_path + "/bashrc_git",
+            'require' => "Vcsrepo[" + $dotfiles_path + "]",
           )
         }
         it { is_expected.to contain_file_line($user + "_bashrc_gitprompt")
           .with(
-            'ensure' => 'present',
-            'path'   => $user_home + "/.bashrc",
-            'line'   => '[ -f ~/.bashrc_git ] && . ~/.bashrc_git',
+            'ensure'  => 'present',
+            'path'    => $user_home + "/.bashrc",
+            'line'    => '[ -f ~/.bashrc_git ] && . ~/.bashrc_git',
+            'require' => "File[" + $user_home + "/.bashrc_git]",
           )
         }
       end


### PR DESCRIPTION
- add require to all resources depending on
  vcsrepo, so that no symlinks are created, .bashrc is untouched
  if vcsrepo clone fails
